### PR TITLE
remove pypi note. fix superclass init arg name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,8 +46,6 @@ This supports the common 4" and 5.65" ACeP displays.
 
 Installing from PyPI
 =====================
-.. note:: This library is not available on PyPI yet. Install documentation is included
-   as a standard element. Stay tuned for PyPI availability!
 
 On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
 PyPI <https://pypi.org/project/adafruit-circuitpython-spd1656/>`_.

--- a/adafruit_spd1656.py
+++ b/adafruit_spd1656.py
@@ -105,5 +105,5 @@ class SPD1656(displayio.EPaperDisplay):
             busy_state=False,
             write_black_ram_command=0x10,
             refresh_display_command=0x12,
-            acep=True
+            advanced_color_epaper=True
         )


### PR DESCRIPTION
Remove the pypi message as noted in #1 

Also changed the name passed to the superclass `EPaperDisplay` to match it's name in the core: https://github.com/adafruit/circuitpython/blob/dec3cfc95501bc604e564007bb22d0ca3f28c95a/shared-bindings/displayio/EPaperDisplay.c#L122