### PR TITLE
Update with display.root_group for CircuitPython 9 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ Usage Example
     epd_reset = board.D11
     epd_busy = board.D12
 
-    display_bus = displayio.FourWire(
+    display_bus = fourwire.FourWire(
         spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000
     )
 

--- a/README.rst
+++ b/README.rst
@@ -138,7 +138,7 @@ Usage Example
         t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
         g.append(t)
 
-        display.show(g)
+        display.root_group = g
 
         display.refresh()
 

--- a/adafruit_spd1656.py
+++ b/adafruit_spd1656.py
@@ -23,7 +23,7 @@ Implementation Notes
 
 import struct
 
-import displayio
+import epaperdisplay
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_SPD1656.git"
@@ -48,7 +48,7 @@ _STOP_SEQUENCE = b"\x02\x01\x00" b"\x07\x01\xA5"  # Power off then deep sleep
 
 
 # pylint: disable=too-few-public-methods
-class SPD1656(displayio.EPaperDisplay):
+class SPD1656(epaperdisplay.EPaperDisplay):
     r"""SPD1656 display driver
 
     :param bus: The data bus the display is on

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-# autodoc_mock_imports = ["digitalio", "busio"]
+autodoc_mock_imports = ["epaperdisplay"]
 
 autodoc_preserve_defaults = True
 

--- a/examples/spd1656_4in_acep.py
+++ b/examples/spd1656_4in_acep.py
@@ -39,7 +39,7 @@ with open(fn, "rb") as f:
     t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
-    display.show(g)
+    display.root_group = g
 
     display.refresh()
 

--- a/examples/spd1656_4in_acep.py
+++ b/examples/spd1656_4in_acep.py
@@ -11,8 +11,8 @@
 import time
 import board
 import displayio
-import adafruit_spd1656
 import fourwire
+import adafruit_spd1656
 
 
 displayio.release_displays()

--- a/examples/spd1656_4in_acep.py
+++ b/examples/spd1656_4in_acep.py
@@ -12,6 +12,8 @@ import time
 import board
 import displayio
 import adafruit_spd1656
+import fourwire
+
 
 displayio.release_displays()
 
@@ -22,7 +24,7 @@ epd_dc = board.D10
 epd_reset = board.D11
 epd_busy = board.D12
 
-display_bus = displayio.FourWire(
+display_bus = fourwire.FourWire(
     spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000
 )
 

--- a/examples/spd1656_color_stripes.py
+++ b/examples/spd1656_color_stripes.py
@@ -10,8 +10,8 @@ Fill the screen with striped rows, one for each possible color.
 import board
 import displayio
 import bitmaptools
-import adafruit_spd1656
 import fourwire
+import adafruit_spd1656
 
 
 displayio.release_displays()

--- a/examples/spd1656_color_stripes.py
+++ b/examples/spd1656_color_stripes.py
@@ -11,6 +11,8 @@ import board
 import displayio
 import bitmaptools
 import adafruit_spd1656
+import fourwire
+
 
 displayio.release_displays()
 
@@ -21,7 +23,7 @@ epd_dc = board.D10
 epd_reset = board.D11
 epd_busy = board.D12
 
-display_bus = displayio.FourWire(
+display_bus = fourwire.FourWire(
     spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000
 )
 

--- a/examples/spd1656_color_stripes.py
+++ b/examples/spd1656_color_stripes.py
@@ -56,7 +56,7 @@ for i in range(7):
 tg = displayio.TileGrid(bitmap=bmp, pixel_shader=p)
 g.append(tg)
 
-display.show(g)
+display.root_group = g
 
 display.refresh()
 

--- a/examples/spd1656_colors_and_text.py
+++ b/examples/spd1656_colors_and_text.py
@@ -14,6 +14,8 @@ import terminalio
 import bitmaptools
 from adafruit_display_text.bitmap_label import Label
 import adafruit_spd1656
+import fourwire
+
 
 displayio.release_displays()
 
@@ -24,7 +26,7 @@ epd_dc = board.D10
 epd_reset = board.D11
 epd_busy = board.D12
 
-display_bus = displayio.FourWire(
+display_bus = fourwire.FourWire(
     spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000
 )
 

--- a/examples/spd1656_colors_and_text.py
+++ b/examples/spd1656_colors_and_text.py
@@ -55,7 +55,7 @@ lbl.anchor_point = (0.5, 0.5)
 lbl.anchored_position = (display.width // 2, display.height // 2)
 g.append(lbl)
 
-display.show(g)
+display.root_group = g
 display.refresh()
 
 while True:

--- a/examples/spd1656_colors_and_text.py
+++ b/examples/spd1656_colors_and_text.py
@@ -13,8 +13,8 @@ import displayio
 import terminalio
 import bitmaptools
 from adafruit_display_text.bitmap_label import Label
-import adafruit_spd1656
 import fourwire
+import adafruit_spd1656
 
 
 displayio.release_displays()

--- a/examples/spd1656_simpletest.py
+++ b/examples/spd1656_simpletest.py
@@ -10,8 +10,9 @@
 import time
 import board
 import displayio
-import adafruit_spd1656
 import fourwire
+import adafruit_spd1656
+
 
 displayio.release_displays()
 

--- a/examples/spd1656_simpletest.py
+++ b/examples/spd1656_simpletest.py
@@ -38,7 +38,7 @@ with open(fn, "rb") as f:
     t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
-    display.show(g)
+    display.root_group = g
 
     display.refresh()
 

--- a/examples/spd1656_simpletest.py
+++ b/examples/spd1656_simpletest.py
@@ -11,6 +11,7 @@ import time
 import board
 import displayio
 import adafruit_spd1656
+import fourwire
 
 displayio.release_displays()
 
@@ -21,7 +22,7 @@ epd_dc = board.D10
 epd_reset = board.D11
 epd_busy = board.D12
 
-display_bus = displayio.FourWire(
+display_bus = fourwire.FourWire(
     spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000
 )
 


### PR DESCRIPTION
This PR replaces `display.show` with `display.root_group` in the 4 example files and the README